### PR TITLE
Set `config.read_only` to be private, to prevent users from accidentally reading its value.

### DIFF
--- a/lib/rails_readonly_injector.rb
+++ b/lib/rails_readonly_injector.rb
@@ -15,7 +15,7 @@ module RailsReadonlyInjector
         next
       end
 
-      if self.config.read_only
+      if self.config.send(:read_only)
         override_readonly_method(klass)
       else
         restore_readonly_method(klass)
@@ -34,7 +34,7 @@ module RailsReadonlyInjector
       # Return the previously stored value
       self.config.changed_attributes[:read_only]
     else
-      self.config.read_only
+      self.config.send(:read_only)
     end
   end
 

--- a/lib/rails_readonly_injector/configuration.rb
+++ b/lib/rails_readonly_injector/configuration.rb
@@ -1,7 +1,7 @@
 module RailsReadonlyInjector
 
   class Configuration
-    attr_reader :read_only, :controller_rescue_action, :classes_to_include, :classes_to_exclude
+    attr_reader :controller_rescue_action, :classes_to_include, :classes_to_exclude
 
     def initialize
       @read_only = false
@@ -88,6 +88,10 @@ module RailsReadonlyInjector
     # so that `#dirty?` returns false 
     def reset_dirty_status!
      @changed_attributes = Hash.new
+    end
+
+    def read_only
+      @read_only
     end
   end
   private_constant :Configuration


### PR DESCRIPTION
## Problem
`RailsReadonlyInjector.config.read_only` does not always reflect the current state of the app. For example, if I set `read_only` to `true` and then run `reload!`, the site will be readonly. If I then set `read_only` to `false` and do not run `reload!`, however, `read_only` would state `false`, but the site would infact still be readonly.

The documentation has been updated to make it clear that the `RailsReadonlyInjector.in_read_only_mode?` method should be used to see whether read-only mode is enabled, but I don't think it is clear/obvious enough.

#### Related issues:
https://github.com/xtrasimplicity/rails_readonly_injector/issues/1
<!-- Describe the problem that this PR resolves -->

## How this PR resolves the problem
I've marked `RailsReadonlyInjector.config.read_only` as private and removed the `attr_reader` definition. Users can still access the value using `send`, but they would have to go out of their way to do so.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xtrasimplicity/rails_readonly_injector/5)
<!-- Reviewable:end -->
