### PR TITLE
Added Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to Reproduce the Problem
+
+  1.
+  1.
+  1.
+
+## Specifications
+
+  - Version:
+  - Platform:
+  - Subsystem:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,8 +7,9 @@
 ## Steps to Reproduce the Problem
 
   1.
-  1.
-  1.
+  2.
+  3.
+  4.
 
 ## Specifications
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Problem
+
+<!-- Describe the problem that this PR resolves -->
+
+#### Related issues:
+<!-- Link to issues that are related to this problem. If there aren't any, you can remove the heading. -->
+
+## How this PR resolves the problem
+
+<!--- Describe how your PR resolves this problem -->
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue).
+- [ ] New feature (non-breaking change which adds functionality).
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] I've added tests for my code.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.


### PR DESCRIPTION
## Problem
There's no standard template for Issues & PRs.

## How this PR resolves the problem
It adds the two Github templates to `.github`
<!--- Describe how your PR resolves this problem -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xtrasimplicity/rails_readonly_injector/6)
<!-- Reviewable:end -->
