### PR TITLE
Fixed test-related rake tasks

### DIFF
--- a/development_tasks/tests.rake
+++ b/development_tasks/tests.rake
@@ -62,10 +62,7 @@ namespace :dev do
   end
 
   desc "Synchronises tests from `cucumber_features` and `rspec_specs` into the rails application in #{RAILS_APP_PATH}, and runs the tests against the application."
-  task :run_tests do
-    Rake::Task['dev:run_features'].invoke
-    Rake::Task['dev:run_specs'].invoke
-  end
+  task :run_tests => [:run_features, :run_specs]
 
   desc "Synchronises features from `cucumber_features` into the rails application in #{RAILS_APP_PATH}, and runs them against the application."
   task :run_features do
@@ -76,8 +73,9 @@ namespace :dev do
 
     unset_appraisal_environment_variables
 
-    exit_code = system('bundle exec cucumber')
-    exit exit_code
+    command_executed_successfully = system('bundle exec cucumber')
+    
+    exit 1 unless command_executed_successfully
   end
 
   desc "Synchronises specs from `rspec_specs` into the rails application in #{RAILS_APP_PATH}, and runs them against the application."
@@ -89,8 +87,10 @@ namespace :dev do
 
     unset_appraisal_environment_variables
 
-    exit_code = system('bundle exec rspec')
-    exit exit_code
+    
+    command_executed_successfully = system('bundle exec rspec')
+    
+    exit 1 unless command_executed_successfully
   end
 
   def parse_gemfile(file_path)

--- a/rspec_specs/rails_readonly_injector_spec.rb
+++ b/rspec_specs/rails_readonly_injector_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RailsReadonlyInjector do
     subject { RailsReadonlyInjector.config }
 
     it 'sets `read_only` to false' do
-      expect(RailsReadonlyInjector.config.read_only).to eq(false)
+      expect(RailsReadonlyInjector.config.send(:read_only)).to eq(false)
     end
   end
 
@@ -89,7 +89,7 @@ RSpec.describe RailsReadonlyInjector do
         before { RailsReadonlyInjector.config.classes_to_exclude = [User] }
 
         it 'returns the current value' do
-          expect(RailsReadonlyInjector.in_read_only_mode?).to eq(RailsReadonlyInjector.config.read_only)
+          expect(RailsReadonlyInjector.in_read_only_mode?).to eq(RailsReadonlyInjector.config.send(:read_only))
         end
       end
     end


### PR DESCRIPTION
## Problem
When the `dev:run_features` rake task completed successfully, it would trigger the process to exit, stopping RSpec specs from executing.

## How this PR resolves the problem
I've set the tasks to only trigger the process to exit, if the task fails to complete successfully.
Additionally, I've also fixed the tests. :)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.